### PR TITLE
Add client Providers and keep layout server-side

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import Providers from "./providers";
 
 export const metadata = {
     title: "Luis Ramon | Portfolio",
@@ -12,7 +13,9 @@ export default function RootLayout({
 }) {
     return (
         <html lang="en">
-            <body>{children}</body>
+            <body>
+                <Providers>{children}</Providers>
+            </body>
         </html>
     );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { HeroUIProvider } from "@heroui/react";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+    return <HeroUIProvider>{children}</HeroUIProvider>;
+}


### PR DESCRIPTION
Introduce a client-only **Providers** component to host HeroUI context while keeping `app/layout.tsx` as a Server Component.

- Added `src/app/providers.tsx` ("use client") with `HeroUIProvider`.
- Wrapped the app tree with `<Providers>` in `src/app/layout.tsx`.
- Ensured global styles load via `globals.css` (HeroUI + Tailwind).